### PR TITLE
Remove -lpthread and any -L flags from pkg-config libs.

### DIFF
--- a/src/main/scala/im/tox/sbt/AndroidNdkPlugin.scala
+++ b/src/main/scala/im/tox/sbt/AndroidNdkPlugin.scala
@@ -29,6 +29,10 @@ object AndroidNdkPlugin extends AutoPlugin {
     )
   }
 
+  private def removeBreakingLibs(flags: Seq[String]): Seq[String] = {
+    flags.filterNot(flag => flag == "-lpthread" || flag.startsWith("-L"))
+  }
+
   val androidSettings = Seq(
     // Hack to make "publishLocal" build the native library. Since tests don't run when building for Android,
     // there is otherwise no reason to build the library.
@@ -54,9 +58,8 @@ object AndroidNdkPlugin extends AutoPlugin {
     ldConfigFlags += "-Wl,-z,defs",
     ldConfigFlags += "-latomic",
 
-    ldConfigFlags <<= ldConfigFlags map {
-      _.filterNot(flag => flag == "-lpthread" || flag.startsWith("-L"))
-    }
+    ldConfigFlags := removeBreakingLibs(ldConfigFlags.value),
+    libLdConfigFlags := removeBreakingLibs(libLdConfigFlags.value)
   )
 
   override def projectSettings: Seq[Setting[_]] = androidSettings

--- a/src/main/scala/im/tox/sbt/Java7Plugin.scala
+++ b/src/main/scala/im/tox/sbt/Java7Plugin.scala
@@ -1,0 +1,18 @@
+package im.tox.sbt
+
+import sbt.Keys._
+import sbt._
+import sbt.plugins.{ IvyPlugin, JvmPlugin }
+
+object Java7Plugin extends AutoPlugin {
+
+  override def trigger: PluginTrigger = allRequirements
+  override def requires: Plugins = JvmPlugin
+
+  override def projectSettings: Seq[Setting[_]] = Seq(
+    // All TokTok projects must be compatible with Java 7 so they work on
+    // Android devices.
+    javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
+  )
+
+}


### PR DESCRIPTION
These break linking for Android, because sysroot/usr/lib contains a
`libstdc++.{a,so}` without the actual C++ standard library in it.
