### PR TITLE
Update for new SBT API.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization  := "org.toktok"
 name          := "sbt-plugins"
-version       := "0.1.0"
+version       := "0.1.1"
 scalaVersion  := "2.10.6"
 
 sbtPlugin := true

--- a/src/main/scala/im/tox/sbt/AndroidNdkPlugin.scala
+++ b/src/main/scala/im/tox/sbt/AndroidNdkPlugin.scala
@@ -36,7 +36,7 @@ object AndroidNdkPlugin extends AutoPlugin {
   val androidSettings = Seq(
     // Hack to make "publishLocal" build the native library. Since tests don't run when building for Android,
     // there is otherwise no reason to build the library.
-    publishLocal <<= publishLocal.dependsOn(nativeLink in NativeCompile),
+    publishLocal := publishLocal.dependsOn(nativeLink in NativeCompile).value,
 
     ndkHome := sys.env.get("ANDROID_NDK_HOME").map(file).filter(_.exists).getOrElse(file(sys.env("HOME")) / "android-ndk"),
     toolchainHome := baseDirectory.value / "toolchains" / crossPlatform.value,

--- a/src/main/scala/im/tox/sbt/ConfigurePlugin.scala
+++ b/src/main/scala/im/tox/sbt/ConfigurePlugin.scala
@@ -174,18 +174,18 @@ object ConfigurePlugin extends AutoPlugin {
       cxxFeatureFlags.value
     ).flatten,
 
-    commonConfigFlags in NativeCompile <<= commonConfigFlags in Default,
-    libCommonConfigFlags in NativeCompile <<= libCommonConfigFlags in Default,
-    cConfigFlags in NativeCompile <<= cConfigFlags in Default,
-    cxxConfigFlags in NativeCompile <<= cxxConfigFlags in Default,
-    ldConfigFlags in NativeCompile <<= ldConfigFlags in Default,
+    commonConfigFlags in NativeCompile := (commonConfigFlags in Default).value,
+    libCommonConfigFlags in NativeCompile := (libCommonConfigFlags in Default).value,
+    cConfigFlags in NativeCompile := (cConfigFlags in Default).value,
+    cxxConfigFlags in NativeCompile := (cxxConfigFlags in Default).value,
+    ldConfigFlags in NativeCompile := (ldConfigFlags in Default).value,
 
-    commonConfigFlags in NativeTest <<= commonConfigFlags in NativeCompile,
-    libCommonConfigFlags in NativeTest <<= libCommonConfigFlags in NativeCompile,
-    cConfigFlags in NativeTest <<= cConfigFlags in NativeCompile,
-    cxxConfigFlags in NativeTest <<= cxxConfigFlags in NativeCompile,
-    ldConfigFlags in NativeTest <<= ldConfigFlags in NativeCompile,
-    libLdConfigFlags in NativeTest <<= libLdConfigFlags in NativeCompile
+    commonConfigFlags in NativeTest := (commonConfigFlags in NativeCompile).value,
+    libCommonConfigFlags in NativeTest := (libCommonConfigFlags in NativeCompile).value,
+    cConfigFlags in NativeTest := (cConfigFlags in NativeCompile).value,
+    cxxConfigFlags in NativeTest := (cxxConfigFlags in NativeCompile).value,
+    ldConfigFlags in NativeTest := (ldConfigFlags in NativeCompile).value,
+    libLdConfigFlags in NativeTest := (libLdConfigFlags in NativeCompile).value
   )
 
   override def projectSettings: Seq[Setting[_]] =

--- a/src/main/scala/im/tox/sbt/GoogleTestPlugin.scala
+++ b/src/main/scala/im/tox/sbt/GoogleTestPlugin.scala
@@ -20,12 +20,12 @@ object GoogleTestPlugin extends AutoPlugin {
 
   val gtestSettings = Seq(
     googleTestRepoUrl := url("https://github.com/google/googletest"),
-    googleTestSource <<= sourceManaged { _ / "googletest" },
+    googleTestSource := sourceManaged.value / "googletest",
 
-    managedSourceDirectories <+= googleTestSource { _ / "googletest" },
-    managedSourceDirectories <+= googleTestSource { _ / "googletest/include" },
+    managedSourceDirectories += googleTestSource.value / "googletest",
+    managedSourceDirectories += googleTestSource.value / "googletest/include",
 
-    googleTestDownload <<= Def.task {
+    googleTestDownload := {
       if (!crossCompiling.value && !googleTestSource.value.exists) {
         val log = streams.value.log
 
@@ -37,7 +37,7 @@ object GoogleTestPlugin extends AutoPlugin {
       (googleTestSource.value / "googletest/src/gtest-all.cc").get
     },
 
-    sourceGenerators <+= googleTestDownload
+    sourceGenerators += googleTestDownload.taskValue
   )
 
   override def projectSettings: Seq[Setting[_]] = inConfig(NativeTest)(gtestSettings)

--- a/src/main/scala/im/tox/sbt/JavahPlugin.scala
+++ b/src/main/scala/im/tox/sbt/JavahPlugin.scala
@@ -30,7 +30,7 @@ object JavahPlugin extends AutoPlugin {
       NativeClassFinder(streams.value.log, classes)
     },
 
-    javah <<= Def.task {
+    javah := {
       val log = streams.value.log
 
       val classpath = (
@@ -56,7 +56,7 @@ object JavahPlugin extends AutoPlugin {
       }
     },
 
-    sourceGenerators <+= javah
+    sourceGenerators += javah.taskValue
   )
 
   override def projectSettings: Seq[Setting[_]] = inConfig(NativeCompile)(settings)

--- a/src/main/scala/im/tox/sbt/MakeScripts.scala
+++ b/src/main/scala/im/tox/sbt/MakeScripts.scala
@@ -39,7 +39,7 @@ object MakeScripts extends AutoPlugin {
     for (main <- mains) {
       val contents = template.format(
         cp.files.get.mkString("\",\n  \""),
-        ("-Xmx1g" +: opts).mkString("\",\n  \""),
+        opts.mkString("\",\n  \""),
         main
       )
       val out = base / "bin" / classBaseName(main)
@@ -49,12 +49,12 @@ object MakeScripts extends AutoPlugin {
   }
 
   override val projectSettings: Seq[Setting[_]] = {
-    makeScripts <<= (
-      baseDirectory,
-      javaOptions in Test,
-      fullClasspath in Test,
-      discoveredMainClasses in Test
-    ) map makeScriptsTask
+    makeScripts := makeScriptsTask(
+      baseDirectory.value,
+      (javaOptions in Test).value,
+      (fullClasspath in Test).value,
+      (discoveredMainClasses in Test).value
+    )
   }
 
 }

--- a/src/main/scala/im/tox/sbt/NativeTestPlugin.scala
+++ b/src/main/scala/im/tox/sbt/NativeTestPlugin.scala
@@ -34,13 +34,13 @@ object NativeTestPlugin extends AutoPlugin {
       }
     },
 
-    nativeLink <<= (
-      streams,
-      cxx, ldConfigFlags,
-      nativeCompile,
-      nativeLink in NativeCompile,
-      nativeProgramOutput
-    ) map NativeCompilation.linkProgram
+    nativeLink := NativeCompilation.linkProgram(
+      streams.value,
+      cxx.value, ldConfigFlags.value ++ ldEnvFlags.value ++ libLdConfigFlags.value,
+      nativeCompile.value,
+      (nativeLink in NativeCompile).value,
+      nativeProgramOutput.value
+    )
   )
 
   val running = Seq(
@@ -49,7 +49,6 @@ object NativeTestPlugin extends AutoPlugin {
       "-Xmx1g",
       "-Xbatch",
       "-Xcheck:jni",
-      "-Xfuture",
       "-Djava.library.path=" + crossTarget.value
     )
   )

--- a/src/main/scala/im/tox/sbt/PkgConfigPlugin.scala
+++ b/src/main/scala/im/tox/sbt/PkgConfigPlugin.scala
@@ -42,15 +42,15 @@ object PkgConfigPlugin extends AutoPlugin {
     pkgConfigCflags := pkgConfig(streams.value.log, nativeLibraryDependencies.value, pkgConfigPath.value, "cflags"),
     pkgConfigLibs := pkgConfig(streams.value.log, nativeLibraryDependencies.value, pkgConfigPath.value, "libs"),
 
-    libCommonConfigFlags <++= pkgConfigCflags,
-    libLdConfigFlags <++= pkgConfigLibs
+    libCommonConfigFlags ++= pkgConfigCflags.value,
+    libLdConfigFlags ++= pkgConfigLibs.value
   )
 
   override def projectSettings: Seq[Setting[_]] =
     pkgconfigConfig ++ Seq(
       nativeLibraryDependencies := Nil,
-      nativeLibraryDependencies in NativeCompile <<= nativeLibraryDependencies,
-      nativeLibraryDependencies in NativeTest <<= nativeLibraryDependencies
+      nativeLibraryDependencies in NativeCompile := nativeLibraryDependencies.value,
+      nativeLibraryDependencies in NativeTest := nativeLibraryDependencies.value
     )
 
 }

--- a/src/main/scala/im/tox/sbt/ProtobufNativePlugin.scala
+++ b/src/main/scala/im/tox/sbt/ProtobufNativePlugin.scala
@@ -22,15 +22,15 @@ object ProtobufNativePlugin extends AutoPlugin {
   import Keys._
 
   override def projectSettings: Seq[Setting[_]] = inConfig(protobufConfig)(Seq(
-    generateCpp <<= (
-      streams,
-      runProtoc,
-      sourceManaged in NativeCompile,
-      sourceDirectory,
-      crossPlatform in NativeCompile
-    ) map sourceGeneratorTask,
+    generateCpp := sourceGeneratorTask(
+      streams.value,
+      runProtoc.value,
+      (sourceManaged in NativeCompile).value,
+      sourceDirectory.value,
+      (crossPlatform in NativeCompile).value
+    ),
 
-    sourceGenerators in NativeCompile <+= generateCpp
+    sourceGenerators in NativeCompile += generateCpp.taskValue
   ))
 
   private def sourceGeneratorTask(

--- a/src/main/scala/im/tox/sbt/ProtobufScalaPlugin.scala
+++ b/src/main/scala/im/tox/sbt/ProtobufScalaPlugin.scala
@@ -12,12 +12,12 @@ object ProtobufScalaPlugin extends AutoPlugin {
   override def requires: Plugins = IvyPlugin && JvmPlugin
 
   override def projectSettings: Seq[Setting[_]] = protobufSettings ++ inConfig(protobufConfig)(Seq(
-    runProtoc in protobufConfig := Def.task { (args: Seq[String]) =>
+    runProtoc in protobufConfig := { (args: Seq[String]) =>
       Protoc.runProtoc(args.toArray)
-    }.value,
+    },
 
-    javaSource <<= (sourceManaged in Compile),
-    scalaSource <<= (sourceManaged in Compile),
+    javaSource := (sourceManaged in Compile).value,
+    scalaSource := (sourceManaged in Compile).value,
 
     version := "3.0.0",
     javaConversions := true,


### PR DESCRIPTION
Some old operators were deprecated in sbt 0.13.

See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-sbt-plugins/2)
<!-- Reviewable:end -->
