### PR TITLE
Pass dependency includes as `-isystem`.

### DIFF
--- a/src/main/scala/im/tox/sbt/PkgConfigPlugin.scala
+++ b/src/main/scala/im/tox/sbt/PkgConfigPlugin.scala
@@ -14,8 +14,8 @@ object PkgConfigPlugin extends AutoPlugin {
     val pkgConfigPath = settingKey[String]("Search path for pkg-config.")
     val nativeLibraryDependencies = settingKey[Seq[ModuleID]]("Native library dependencies (pkg-config).")
 
-    val pkgConfigCflags = taskKey[Seq[String]]("???")
-    val pkgConfigLibs = taskKey[Seq[String]]("???")
+    val pkgConfigCflags = taskKey[Seq[String]]("CFLAGS from pkg-config --cflags")
+    val pkgConfigLibs = taskKey[Seq[String]]("LDFLAGS from pkg-config --libs")
   }
 
   import autoImport._
@@ -39,7 +39,10 @@ object PkgConfigPlugin extends AutoPlugin {
   val pkgconfigConfig = Seq(
     pkgConfigPath := sys.env.getOrElse("PKG_CONFIG_PATH", ""),
 
-    pkgConfigCflags := pkgConfig(streams.value.log, nativeLibraryDependencies.value, pkgConfigPath.value, "cflags"),
+    pkgConfigCflags := {
+      val cflags = pkgConfig(streams.value.log, nativeLibraryDependencies.value, pkgConfigPath.value, "cflags")
+      cflags ++ cflags.filter(_.startsWith("-I")).map(_.replace("-I", "-isystem"))
+    },
     pkgConfigLibs := pkgConfig(streams.value.log, nativeLibraryDependencies.value, pkgConfigPath.value, "libs"),
 
     libCommonConfigFlags ++= pkgConfigCflags.value,


### PR DESCRIPTION
The C++ protobuf library causes a lot of warnings. We want to avoid
cluttering the build log with those (several megabytes of) warnings. They
make it hard to find actual warnings in the mess and make the potential
future use of `-Werror` impossible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-sbt-plugins/7)
<!-- Reviewable:end -->
