### PR TITLE
Don't use `git.depth=1` anymore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,3 @@ cache:
 branches:
   only:
   - master
-
-git:
-  depth: 1


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-sbt-plugins/9)
<!-- Reviewable:end -->
