### PR TITLE
chore: Don't try to resolve now-sunset bintray repositories

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ scalaVersion  := "2.10.7"
 sbtPlugin := true
 
 resolvers += Classpaths.sbtPluginReleases
-resolvers += Resolver.bintrayRepo("toktok", "maven")
 
 // Code style.
 addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "3.1.1")


### PR DESCRIPTION
Building against a local repository still works fine, but the build
takes a lot longer as it has to time out trying to resolve bintray
repositories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-sbt-plugins/22)
<!-- Reviewable:end -->
